### PR TITLE
Solve the chart buttons issue when they're disabled

### DIFF
--- a/wcontrol/src/templates/index.html
+++ b/wcontrol/src/templates/index.html
@@ -84,7 +84,7 @@
                                     <option id={{ i }}>{{ control[i][2] }}</option>
                                 {% endfor %}
                             </select>
-                            <button class="btn btn-default" id="chart_left">
+                            <button class="btn btn-default" id="chart_left" type="button">
                                 <span class="glyphicon glyphicon-chevron-left"></span>
                             </button>
                             <select class="form-control" id="chart_cant">
@@ -94,7 +94,7 @@
                                 <option id=18>18</option>
                                 <option id=24>24</option>
                             </select>
-                            <button class="btn btn-default" id="chart_right">
+                            <button class="btn btn-default" id="chart_right" type="button">
                                 <span class="glyphicon glyphicon-chevron-right"></span>
                             </button>
                             </div>


### PR DESCRIPTION
This commit eliminates the issue that makes the index page reload when the buttons are pressed.