### PR TITLE
Change default control value

### DIFF
--- a/wcontrol/src/models.py
+++ b/wcontrol/src/models.py
@@ -129,32 +129,39 @@ class Control(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
     date = db.Column(db.DateTime)
-    weight = db.Column(db.Float(Precision=2), default=0)
-    bmi = db.Column(db.Float(Precision=2), default=0)
-    fat = db.Column(db.Float(Precision=2), default=0)
-    muscle = db.Column(db.Float(Precision=2), default=0)
-    visceral = db.Column(db.Float(Precision=2), default=0)
-    rmr = db.Column(db.Float(Precision=2), default=0)
-    bodyage = db.Column(db.Float(Precision=2), default=0)
+    weight = db.Column(db.Float(Precision=2))
+    bmi = db.Column(db.Float(Precision=2))
+    fat = db.Column(db.Float(Precision=2))
+    muscle = db.Column(db.Float(Precision=2))
+    visceral = db.Column(db.Float(Precision=2))
+    rmr = db.Column(db.Float(Precision=2))
+    bodyage = db.Column(db.Float(Precision=2))
 
     def __repr__(self):
         return '<Control %r>' % (self.id)
 
     def __getitem__(self, index):
         if index == 0:
-            return [self.weight, MEASUREMENTS[0][1], MEASUREMENTS[0][2]]
+            return [self.weight if self.weight else '-',
+                    MEASUREMENTS[0][1], MEASUREMENTS[0][2]]
         if index == 1:
-            return [self.bmi, MEASUREMENTS[1][1], MEASUREMENTS[1][2]]
+            return [self.bmi if self.bmi else '-',
+                    MEASUREMENTS[1][1], MEASUREMENTS[1][2]]
         if index == 2:
-            return [self.fat, MEASUREMENTS[2][1], MEASUREMENTS[2][2]]
+            return [self.fat if self.fat else '-',
+                    MEASUREMENTS[2][1], MEASUREMENTS[2][2]]
         if index == 3:
-            return [self.muscle, MEASUREMENTS[3][1], MEASUREMENTS[3][2]]
+            return [self.muscle if self.muscle else '-',
+                    MEASUREMENTS[3][1], MEASUREMENTS[3][2]]
         if index == 4:
-            return [self.visceral, MEASUREMENTS[4][1], MEASUREMENTS[4][2]]
+            return [self.visceral if self.visceral else '-',
+                    MEASUREMENTS[4][1], MEASUREMENTS[4][2]]
         if index == 5:
-            return [self.rmr, MEASUREMENTS[5][1], MEASUREMENTS[5][2]]
+            return [self.rmr if self.rmr else '-',
+                    MEASUREMENTS[5][1], MEASUREMENTS[5][2]]
         if index == 6:
-            return [self.bodyage, MEASUREMENTS[6][1], MEASUREMENTS[6][2]]
+            return [self.bodyage if self.bodyage else '-',
+                    MEASUREMENTS[6][1], MEASUREMENTS[6][2]]
         if index == 7:
             return [self.date, '', '']
 

--- a/wcontrol/src/results.py
+++ b/wcontrol/src/results.py
@@ -12,11 +12,15 @@ class results(object):
         self.bodyage = ''
 
     def get_bmi(self, bmi):
+        if not bmi:
+            return '-'
         for limit, msg in BMI:
             if bmi <= limit:
                 return msg
 
     def get_fat(self, fat, gender):
+        if not fat:
+            return '-'
         for limit_w, limit_m, msg in BFP:
             if gender == 'Female' and fat <= limit_w:
                 return msg
@@ -24,6 +28,8 @@ class results(object):
                 return msg
 
     def get_muscle(self, muscle, gender):
+        if not muscle:
+            return '-'
         for limit_w, limit_m, msg in MUSCLE:
             if gender == 'Female' and muscle <= limit_w:
                 return msg
@@ -31,6 +37,8 @@ class results(object):
                 return msg
 
     def get_visceral(self, visceral):
+        if not visceral:
+            return '-'
         for limit, msg in VISCERAL:
             if visceral <= limit:
                 return msg


### PR DESCRIPTION
When a measurement it's not selected, the default value was '0.0'
so on the chart and the results show wrong data.
Now, the default value is None and these values are not considered
to chart either to get results